### PR TITLE
Switch to protocol buffers

### DIFF
--- a/getResourcesCSV.sh
+++ b/getResourcesCSV.sh
@@ -148,7 +148,7 @@ getRequestsAndLimits () {
         mem_limit=$(formatMemory "$(echo "${l}" | awk -F, '{print $7}')")
 
         # Adding pod and container actual usage with pod top data
-        line=$(kubectl top pod --use-protocol-buffers -n ${namespace} ${pod} --containers | grep " ${container} ")
+        line=$(kubectl top pod -n ${namespace} ${pod} --containers --use-protocol-buffers | grep " ${container} ")
 
         cpu_usage=$(formatCpu "$(echo "${line}" | awk '{print $3}')")
         memory_usage=$(formatMemory "$(echo "${line}" | awk '{print $4}')")

--- a/getResourcesCSV.sh
+++ b/getResourcesCSV.sh
@@ -148,7 +148,7 @@ getRequestsAndLimits () {
         mem_limit=$(formatMemory "$(echo "${l}" | awk -F, '{print $7}')")
 
         # Adding pod and container actual usage with pod top data
-        line=$(kubectl top pod -n ${namespace} ${pod} --containers | grep " ${container} ")
+        line=$(kubectl top pod --use-protocol-buffers -n ${namespace} ${pod} --containers | grep " ${container} ")
 
         cpu_usage=$(formatCpu "$(echo "${line}" | awk '{print $3}')")
         memory_usage=$(formatMemory "$(echo "${line}" | awk '{print $4}')")


### PR DESCRIPTION
This change is to suppress this info

`W0925 14:55:10.484073   94990 top_pod.go:140] Using json format to get metrics. Next release will switch to protocol-buffers, switch early by passing --use-protocol-buffers flag`

While doing `kubectl top pod` command